### PR TITLE
Add compatibility aliases for the renamed export report proto types.

### DIFF
--- a/cost/v1/compat_deprecated.go
+++ b/cost/v1/compat_deprecated.go
@@ -1,0 +1,17 @@
+package cost
+
+// Deprecated compatibility aliases for renamed proto message types.
+//
+// AwsRispExportOptions was renamed to AwsExportReportOptions to reflect that
+// the ExportReport API now supports all registered AWS export-report query
+// domains.
+
+// Migration:
+//   - Replace AwsRispExportOptions with AwsExportReportOptions
+//   - Replace AwsRispExportOptions_Columns with AwsExportReportOptions_Columns
+
+// Deprecated: use AwsExportReportOptions instead.
+type AwsRispExportOptions = AwsExportReportOptions
+
+// Deprecated: use AwsExportReportOptions_Columns instead.
+type AwsRispExportOptions_Columns = AwsExportReportOptions_Columns


### PR DESCRIPTION
AwsRispExportOptions was renamed to AwsExportReportOptions to reflect that the export report API now supports multiple AWS export report domains beyond RISP.

This PR adds deprecated Go type aliases so existing consumers can continue using the old names while migrating to the new generic types.